### PR TITLE
Replace direct traffic to node.js

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -1,5 +1,5 @@
 var request = require('request'),
-  util = require('util')
+    util = require('util');
 
 var GoogleAnalytics = function(ua, host) {
   this.ua = ua;
@@ -7,30 +7,40 @@ var GoogleAnalytics = function(ua, host) {
   this.debug = false;
 };
 
-GoogleAnalytics.prototype._serialize = function(obj) {
+GoogleAnalytics.prototype._serialize = function(values) {
   var str = [];
-  for(var p in obj)
-    str.push(p + "=" + encodeURIComponent(obj[p]));
-  return str.join("&");
+  for (var key in values) {
+    str.push(key + '=' + encodeURIComponent(values[key]));
+  }
+
+  return str.join('&');
 };
 
 GoogleAnalytics.prototype._makeRequest = function(obj, cb) {
   var self = this;
   var userId = null;
+
+  var today = new Date().getTime().toString();
+
+  var firstNumber;
+
   if (obj.userId) {
     userId = obj.userId;
     delete obj.userId;
+    firstNumber = userId.substr(0, userId.indexOf('.'));
   } else {
-    userId = Math.round(Math.random()*1000000);
+    random = Math.round(Math.random() * 1000000);
+    userId = random + '.' + random + '.' + today + '.' + today + '.' + today + '.3';
+    firstNumber = random;
   }
-  var today = new Date().getTime().toString();
+
   obj.utmac = this.ua;
   obj.utmn = today;
-  obj.guid = "ON";
-  obj.utmv = "1";
-  obj.utmr= "-";
-  obj.utmcc = "__utma="+userId+"."+userId+"."+today+"."+today+"."+today+".3; __utmz="+userId+"."+today+".1.1.utmcsr=(nodejs)|utmccn=(not set)|utmcmd=(none);";
-  var url = "http://www.google-analytics.com/__utm.gif?"+this._serialize(obj);
+  obj.guid = 'ON';
+  obj.utmv = '1';
+  obj.utmr = '-';
+  obj.utmcc = '__utma=' + userId + '; __utmz=' + firstNumber + '.' + today + '.1.1.utmcsr=(nodejs)|utmccn=(nodejs)|utmcmd=(none);';
+  var url = 'http://www.google-analytics.com/__utm.gif?' + this._serialize(obj);
 
   request({
     url: url
@@ -71,7 +81,7 @@ GoogleAnalytics.prototype.trackEvent = function(event, userId, cb) {
     userId = null;
   }
 
-  ['category', 'action', 'label'].forEach(function(key) {
+['category', 'action', 'label'].forEach(function(key) {
     var val = event[key];
     if (val != null) {
       payload.push(val);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ga",
   "description": "server side google analytics",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "homepage": "https://github.com/jgallen23/node-ga",
   "authors": ["Greg Allen, @jgaui"],
   "repository": {


### PR DESCRIPTION
If we use direct as source we see a lot of visits that are not true (they are just node.js events)
